### PR TITLE
Fixed register function on OAS-Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-[![NPM](https://nodei.co/npm/oas-tools.png?compact=true)](https://nodei.co/npm/oas-devtools/)
+[![NPM](https://nodei.co/npm/oas-devtools.png?compact=true)](https://nodei.co/npm/oas-devtools/)
 
 ![npm](https://img.shields.io/npm/v/oas-devtools)
 ![node-current](https://img.shields.io/node/v/oas-devtools)

--- a/src/middleware/base.js
+++ b/src/middleware/base.js
@@ -1,3 +1,14 @@
+const operations = [
+  "get",
+  "post",
+  "put",
+  "patch",
+  "delete",
+  "head",
+  "options",
+  "trace",
+];
+
 export class OASBase {
   #middleware;
 
@@ -10,9 +21,11 @@ export class OASBase {
 
   register(app) {
     Object.entries(this.#oasFile.paths).forEach(([path, methodObj]) => {
-      Object.keys(methodObj).forEach((method) => {
-        app[method](path, this.#middleware);
-      });
+      Object.keys(methodObj)
+        .filter((key) => operations.includes(key))
+        .forEach((method) => {
+          app[method](path, this.#middleware);
+        });
     });
   }
 


### PR DESCRIPTION
Since `x-router-controller` option can be specified under the paths object (same level as operations), it is necessary to filter valid operations in order to avoid express throwing an error when registering the middleware in the chain.